### PR TITLE
Add Price Tag Component

### DIFF
--- a/frontend/src/app/routes/RouteSearchResult.tsx
+++ b/frontend/src/app/routes/RouteSearchResult.tsx
@@ -21,6 +21,7 @@ interface RouteSearchResultProps {
   deltaTime: number;
   stations: Station[];
   isToday: boolean | null;
+  price?: number;
 }
 
 const RouteSearchResult: React.FC<RouteSearchResultProps> = ({
@@ -33,6 +34,7 @@ const RouteSearchResult: React.FC<RouteSearchResultProps> = ({
   deltaTime,
   stations,
   isToday: initialIsToday,
+  price,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const router = useRouter();
@@ -99,6 +101,7 @@ const RouteSearchResult: React.FC<RouteSearchResultProps> = ({
           <ArrowRightAltIcon />
           {arrivalStation?.name || 'Nepoznata odredišna stanica'}: {arrivalTime}
         </h3>
+        <PriceDisplay price={price} />
         <p>
           Trajanje: {deltaTime}{' '}
           {getGrammaticalForm(deltaTime, 'minuta', 'minute', 'minuta')}
@@ -124,3 +127,14 @@ const RouteSearchResult: React.FC<RouteSearchResultProps> = ({
 };
 
 export default RouteSearchResult;
+
+const PriceDisplay = ({ price }: { price?: number }) => {
+  if (price === undefined)
+    return (
+      <p>
+        Cijena trenutno nije dostupna. Za informacije o cijeni kontaktirajte
+        agenciju.
+      </p>
+    );
+  return <p>Cijena: {price} BAM</p>;
+};


### PR DESCRIPTION
This PR adds a `PriceDisplay` component in the `RouteSearchResult` component.
It currently displays a placeholder text, but it can show the price in BAM when passed a `price:number` prop.

This PR does a small contribution towards the issue #8 .