### PR TITLE
feat: Persist search state in URL to fix back navigation

### DIFF
--- a/frontend/src/app/components/HomePage.tsx
+++ b/frontend/src/app/components/HomePage.tsx
@@ -18,9 +18,7 @@ import RouteService from "../services/route.service";
 import StationService from "../services/station.service";
 import FilterService from "../handlers/route.filter.handler";
 import { toSortedStationsAlphabetically } from "@/lib/utils";
-// START: Import necessary hooks for routing
 import { useRouter, useSearchParams } from "next/navigation";
-// END: Import necessary hooks for routing
 
 const HomePage: React.FC = () => {
   const [routeResults, setRouteResults] = useState<RouteLap[]>([]);
@@ -61,10 +59,8 @@ const HomePage: React.FC = () => {
   const [isPastDeparturesExpanded, setIsPastDeparturesExpanded] =
     useState(false);
 
-  // START: Initialize router and searchParams
   const router = useRouter();
   const searchParams = useSearchParams();
-  // END: Initialize router and searchParams
 
   const togglePastDepartures = () => {
     setIsPastDeparturesExpanded((prevState) => !prevState);
@@ -131,7 +127,6 @@ const HomePage: React.FC = () => {
     return date ? date.isSame(dayjs(), "day") : false;
   };
   
-  // START: New useEffect to sync state with URL
   useEffect(() => {
     const from = searchParams.get("from");
     const to = searchParams.get("to");
@@ -172,9 +167,7 @@ const HomePage: React.FC = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, stations, originalRoutes]);
-  // END: New useEffect
 
-  // START: Modified handleFilterRoutes to update URL
   const handleFilterRoutes = () => {
     if (!tempDepartureStation || !tempArrivalStation) {
       setError("Molimo odaberite i polaznu i dolaznu stanicu.");
@@ -198,7 +191,6 @@ const HomePage: React.FC = () => {
 
     addStationsToHistory(tempDepartureStation, tempArrivalStation);
   };
-  // END: Modified handleFilterRoutes
 
   const handleSearchButtonClick = () => {
     setShowGame(!showGame);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,10 @@ importers:
     dependencies:
       busez:
         specifier: 'file:'
-        version: 'file:'
+        version: file:(react@18.3.1)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@18.3.1)
     devDependencies:
       turbo:
         specifier: 2.0.14
@@ -4747,6 +4750,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -9252,7 +9260,11 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
-  'busez@file:': {}
+  busez@file:(react@18.3.1):
+    dependencies:
+      react-icons: 5.5.0(react@18.3.1)
+    transitivePeerDependencies:
+      - react
 
   bytes@3.1.2: {}
 
@@ -11452,6 +11464,10 @@ snapshots:
       scheduler: 0.23.2
 
   react-hook-form@7.53.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  react-icons@5.5.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
This PR resolves issue #160 by persisting the search state in the URL query parameters.

Changes:
- Used Next.js `useRouter` and `useSearchParams` to manage the search state.
- When a user performs a search, the parameters are written to the URL.
- When the page loads, it reads parameters from the URL to restore the search state.
- This allows the browser's back button to function correctly, preserving the search results after navigating away from the page.

##### ScreenRec:
[Screencast From 2025-10-08 02-46-30.webm](https://github.com/user-attachments/assets/b76eeebc-2534-42aa-8010-aa41579382e1)
